### PR TITLE
Fix test failures when not run in parallel

### DIFF
--- a/cmd/tps-watcher/main_suite_test.go
+++ b/cmd/tps-watcher/main_suite_test.go
@@ -107,22 +107,6 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	logger = lagertest.NewTestLogger("test")
 
 	bbsPath = string(binaries["bbs"])
-	bbsAddress := fmt.Sprintf("127.0.0.1:%d", 13000+GinkgoParallelNode())
-
-	bbsURL = &url.URL{
-		Scheme: "http",
-		Host:   bbsAddress,
-	}
-
-	auctioneerServer = ghttp.NewServer()
-	auctioneerServer.AppendHandlers(ghttp.RespondWith(http.StatusAccepted, nil))
-
-	bbsArgs = bbstestrunner.Args{
-		Address:           bbsAddress,
-		AuctioneerAddress: auctioneerServer.URL(),
-		EtcdCluster:       strings.Join(etcdRunner.NodeURLS(), ","),
-		ConsulCluster:     consulRunner.ConsulCluster(),
-	}
 })
 
 var _ = BeforeEach(func() {
@@ -131,11 +115,28 @@ var _ = BeforeEach(func() {
 	consulRunner.Start()
 	consulRunner.WaitUntilReady()
 
-	bbsRunner = bbstestrunner.New(bbsPath, bbsArgs)
-	bbsProcess = ginkgomon.Invoke(bbsRunner)
-
 	taskHandlerAddress := fmt.Sprintf("127.0.0.1:%d", receptorPort+1)
 	legacyBBS = Bbs.NewBBS(store, consulRunner.NewSession("a-session"), "http://"+taskHandlerAddress, clock.NewClock(), logger)
+
+	auctioneerServer = ghttp.NewServer()
+	auctioneerServer.AppendHandlers(ghttp.RespondWith(http.StatusAccepted, nil))
+
+	bbsAddress := fmt.Sprintf("127.0.0.1:%d", 13000+GinkgoParallelNode())
+
+	bbsURL = &url.URL{
+		Scheme: "http",
+		Host:   bbsAddress,
+	}
+
+	bbsArgs = bbstestrunner.Args{
+		Address:           bbsAddress,
+		AuctioneerAddress: auctioneerServer.URL(),
+		EtcdCluster:       strings.Join(etcdRunner.NodeURLS(), ","),
+		ConsulCluster:     consulRunner.ConsulCluster(),
+	}
+
+	bbsRunner = bbstestrunner.New(bbsPath, bbsArgs)
+	bbsProcess = ginkgomon.Invoke(bbsRunner)
 
 	bbsClient = bbs.NewClient(bbsURL.String())
 
@@ -165,7 +166,6 @@ var _ = AfterEach(func() {
 	ginkgomon.Kill(receptorRunner, 5)
 	etcdRunner.Stop()
 	consulRunner.Stop()
-	auctioneerServer.Close()
 })
 
 var _ = SynchronizedAfterSuite(func() {


### PR DESCRIPTION
- The auctioneer server was created in a before suite, but was cleaned
  up after each test.
- This worked via pollution when the tests were run in parallel, but
  failed when run serially.

Signed-off-by: Zach Robinson <zrobinson@pivotal.io>