### PR TITLE
Locket retry interval should use 5s instead of 1s to be less aggressive

### DIFF
--- a/cmd/tps-watcher/main.go
+++ b/cmd/tps-watcher/main.go
@@ -127,7 +127,7 @@ func initializeLocketLockMaintainer(logger lager.Logger, watcherConfig config.Wa
 		lockIdentifier,
 		locket.DefaultSessionTTLInSeconds,
 		clock.NewClock(),
-		locket.SQLRetryInterval,
+		locket.RetryInterval,
 	)
 }
 

--- a/cmd/tps-watcher/main_test.go
+++ b/cmd/tps-watcher/main_test.go
@@ -224,7 +224,7 @@ var _ = Describe("TPS", func() {
 					})
 
 					It("grabs the lock and becomes active", func() {
-						Eventually(runner.Buffer, 5*time.Second).Should(gbytes.Say("tps-watcher.started"))
+						Eventually(runner.Buffer, 10*time.Second).Should(gbytes.Say("tps-watcher.started"))
 					})
 				})
 			})


### PR DESCRIPTION
Very fast retries can cause a DoS in locket as existing requests pile up and must be processed 1-at-a-time before new requests are executed (due to SELECT FOR UPDATE holding the row lock)

Summary
========
My environment is slow enough where I occasionally see a locket request take longer than 1s. Components with a 1s retry will give up on the request because it take to long and then immediately make another request for ~15 retries. None of them succeed because they pile up on each other at the locket server.